### PR TITLE
Enhance Starlark definition (Skylark, Python, cross-links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ release builds. Enable through the `--workspace_status_command` flag and rules
 that support the `stamp` attribute.
 
 #### Starlark
-The extension language for writing rules and macros. A restricted subset of
-Python aimed for the purpose of configuration, and for better performance. Uses
-the `.bzl` file extension. `BUILD` files use an even more restricted version of
-Starlark (e.g. no `def` function definitions).
+Formerly known as Skylark, the extension language for writing rules and macros.
+A restricted subset of Python (syntactically and grammatically) aimed for the
+purpose of configuration, and for better performance. Uses the `.bzl` file
+extension. [*`BUILD`*](#BUILD-files) files use an even more restricted version
+of Starlark (e.g. no `def` function definitions).
 
 <!-- **Starlark Build API.** -->
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ that support the `stamp` attribute.
 Formerly known as Skylark, the extension language for writing rules and macros.
 A restricted subset of Python (syntactically and grammatically) aimed for the
 purpose of configuration, and for better performance. Uses the `.bzl` file
-extension. [*`BUILD`*](#BUILD-files) files use an even more restricted version
+extension. [*`BUILD`*](#BUILD-file) files use an even more restricted version
 of Starlark (e.g. no `def` function definitions).
 
 <!-- **Starlark Build API.** -->

--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ release builds. Enable through the `--workspace_status_command` flag and rules
 that support the `stamp` attribute.
 
 #### Starlark
-Formerly known as Skylark, the extension language for writing rules and macros.
-A restricted subset of Python (syntactically and grammatically) aimed for the
-purpose of configuration, and for better performance. Uses the `.bzl` file
-extension. [*`BUILD`*](#BUILD-file) files use an even more restricted version
-of Starlark (e.g. no `def` function definitions).
+The extension language for writing rules and macros. A restricted subset of
+Python (syntactically and grammatically) aimed for the purpose of configuration,
+and for better performance. Uses the `.bzl` file extension.
+[*`BUILD`*](#BUILD-file) files use an even more restricted version
+of Starlark (e.g. no `def` function definitions). Formerly known as Skylark.
 
 <!-- **Starlark Build API.** -->
 


### PR DESCRIPTION
Wording about Skylark is taken from https://docs.bazel.build/versions/master/skylark/language.html

I think it's also crucial to say that it's not actually Python, but rather a syntactical and grammatical subset of it.